### PR TITLE
Feature/govbot 0.0.22 - Login To MEF WebApp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-govbot",
-  "version": "0.0.14",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-govbot",
-      "version": "0.0.14",
+      "version": "0.0.21",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^1.8.2",
@@ -17,6 +17,7 @@
         "discord.js": "^14.15.3",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
+        "jose": "^5.9.6",
         "loglevel": "^1.9.1",
         "loglevel-plugin-prefix": "^0.8.4",
         "sequelize": "^6.37.3",
@@ -4397,6 +4398,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-govbot",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Discord bot for collective decision making for Mina Protocol",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
+    "jose": "^5.9.6",
     "loglevel": "^1.9.1",
     "loglevel-plugin-prefix": "^0.8.4",
     "sequelize": "^6.37.3",

--- a/src/channels/consider/Constants.ts
+++ b/src/channels/consider/Constants.ts
@@ -1,56 +1,56 @@
-// src/channels/consideration/ConsiderationConstants.ts
-
 export const CONSIDERATION_CONSTANTS = {
-    SCREEN_IDS: {
-      HOME: 'considerationHome',
-      SELECT_FUNDING_ROUND: 'selectEligibleFundingRound',
-      SELECT_VOTE_TYPE: 'svts', // Select Vote Type Screen
-      SELECT_ELIGIBLE_PROJECT: 'selectEligibleProject',
-      SELECT_VOTED_PROJECT: 'svps', // Select Voted Project Screen
-      SME_CONSIDERATION_VOTE: 'smeConsiderationVote',
-    },
-  
-    ACTION_IDS: {
-      SELECT_FUNDING_ROUND: 'selectFundingRound',
-      SELECT_VOTE_TYPE: 'svta', // Select Vote Type Action
-      SELECT_PROJECT: 'slPr',
-      SME_CONSIDERATION_VOTE: 'smeConsiderationVote',
-    },
-  
-    OPERATION_IDS: {
-      SHOW_FUNDING_ROUNDS: 'showFundingRounds',
-      SELECT_FUNDING_ROUND: 'selectFundingRound',
-      SHOW_VOTE_TYPES: 'showVoteTypes',
-      SELECT_VOTE_TYPE: 'svto', // Select Vote Type Operation
-      SHOW_PROJECTS: 'showProjects',
-      SELECT_PROJECT: 'slPr',
-      SHOW_VOTE_OPTIONS: 'showVoteOptions',
-      SUBMIT_VOTE: 'submitVote',
-      CONFIRM_VOTE: 'confirmVote',
-    },
-  
-    BUTTON_IDS: {
-      SELECT_FUNDING_ROUND: 'selectFundingRoundBtn',
-      EVALUATE_NEW_PROPOSALS: 'evaluateNewProposalsBtn',
-      UPDATE_PREVIOUS_VOTE: 'updatePreviousVoteBtn',
-      APPROVE_PROJECT: 'approveProjectBtn',
-      REJECT_PROJECT: 'rejectProjectBtn',
-    },
-  
-    INPUT_IDS: {
-      REASON: 'reason',
-    },
-  
-    CUSTOM_ID_ARGS: {
-      FUNDING_ROUND_ID: 'fId',
-      SHOW_UNVOTED: 'showUnvoted',
-      VOTE_TYPE: 'voteType',
-      PROJECT_ID: 'pId',
-      VOTE: 'vote',
-    },
-  
-    VOTE_OPTIONS: {
-      APPROVE: 'approve',
-      REJECT: 'reject',
-    },
-  };
+  SCREEN_IDS: {
+    HOME: 'considerationHome',
+    SELECT_FUNDING_ROUND: 'selectEligibleFundingRound',
+    SELECT_VOTE_TYPE: 'svts', // Select Vote Type Screen
+    SELECT_ELIGIBLE_PROJECT: 'selectEligibleProject',
+    SELECT_VOTED_PROJECT: 'svps', // Select Voted Project Screen
+    SME_CONSIDERATION_VOTE: 'smeConsiderationVote',
+  },
+
+  ACTION_IDS: {
+    SELECT_FUNDING_ROUND: 'selectFundingRound',
+    SELECT_VOTE_TYPE: 'svta', // Select Vote Type Action
+    SELECT_PROJECT: 'slPr',
+    SME_CONSIDERATION_VOTE: 'smeConsiderationVote',
+    GENERATE_LOGIN_TOKEN: 'glt',
+  },
+
+  OPERATION_IDS: {
+    SHOW_FUNDING_ROUNDS: 'showFundingRounds',
+    SELECT_FUNDING_ROUND: 'selectFundingRound',
+    SHOW_VOTE_TYPES: 'showVoteTypes',
+    SELECT_VOTE_TYPE: 'svto', // Select Vote Type Operation
+    SHOW_PROJECTS: 'showProjects',
+    SELECT_PROJECT: 'slPr',
+    SHOW_VOTE_OPTIONS: 'showVoteOptions',
+    SUBMIT_VOTE: 'submitVote',
+    CONFIRM_VOTE: 'confirmVote',
+    GENERATE_LOGIN_TOKEN: 'glt',
+  },
+
+  BUTTON_IDS: {
+    SELECT_FUNDING_ROUND: 'selectFundingRoundBtn',
+    EVALUATE_NEW_PROPOSALS: 'evaluateNewProposalsBtn',
+    UPDATE_PREVIOUS_VOTE: 'updatePreviousVoteBtn',
+    APPROVE_PROJECT: 'approveProjectBtn',
+    REJECT_PROJECT: 'rejectProjectBtn',
+  },
+
+  INPUT_IDS: {
+    REASON: 'reason',
+  },
+
+  CUSTOM_ID_ARGS: {
+    FUNDING_ROUND_ID: 'fId',
+    SHOW_UNVOTED: 'showUnvoted',
+    VOTE_TYPE: 'voteType',
+    PROJECT_ID: 'pId',
+    VOTE: 'vote',
+  },
+
+  VOTE_OPTIONS: {
+    APPROVE: 'approve',
+    REJECT: 'reject',
+  },
+};

--- a/src/channels/consider/actions/GenerateLoginTokenAction.ts
+++ b/src/channels/consider/actions/GenerateLoginTokenAction.ts
@@ -1,0 +1,66 @@
+import { ButtonBuilder, ButtonStyle, EmbedBuilder } from 'discord.js';
+import { Action, Screen, TrackedInteraction } from '../../../core/BaseClasses';
+import { CustomIDOracle } from '../../../CustomIDOracle';
+import { CONSIDERATION_CONSTANTS } from '../Constants';
+import { AuthTokenGenerator } from '../../../utils/jwt';
+import { EndUserError } from '../../../Errors';
+import { DiscordLimiter } from '../../../utils/DiscordLimiter';
+
+export class GenerateLoginTokenAction extends Action {
+  private tokenGenerator: AuthTokenGenerator;
+
+  constructor(screen: Screen, actionId: string) {
+    super(screen, actionId);
+    this.tokenGenerator = new AuthTokenGenerator(
+      process.env.DISCORD_CLIENT_ID!,
+      process.env.MEF_FE_BASE_URL!,
+      process.env.JWT_PRIVATE_KEY_RS512!,
+      process.env.JWT_PUBLIC_KEY_RS512!,
+    );
+  }
+
+  protected async handleOperation(interaction: TrackedInteraction, operationId: string): Promise<void> {
+    switch (operationId) {
+      case CONSIDERATION_CONSTANTS.OPERATION_IDS.GENERATE_LOGIN_TOKEN:
+        await this.handleGenerateLoginToken(interaction);
+        break;
+      default:
+        await this.handleInvalidOperation(interaction, operationId);
+    }
+  }
+
+  private async handleGenerateLoginToken(interaction: TrackedInteraction): Promise<void> {
+    try {
+      if (!interaction.interaction.isButton()) {
+        throw new EndUserError('Invalid interaction type');
+      }
+
+      const loginUrl = await this.tokenGenerator.generateLoginUrl(interaction.interaction);
+
+      const embed = new EmbedBuilder()
+        .setColor('#0099ff')
+        .setTitle('Login to MEF')
+        .setDescription(
+          `Click the link below to log in:\n\n🔐 [Click here to login](${loginUrl})\n\n*This login link will expire in 30 seconds for security.*`,
+        );
+
+      await interaction.respond({
+        embeds: [embed],
+        ephemeral: true,
+      });
+    } catch (error) {
+      throw new EndUserError('Failed to generate login token', error);
+    }
+  }
+
+  public allSubActions(): Action[] {
+    return [];
+  }
+
+  getComponent(): ButtonBuilder {
+    return new ButtonBuilder()
+      .setCustomId(CustomIDOracle.addArgumentsToAction(this, CONSIDERATION_CONSTANTS.OPERATION_IDS.GENERATE_LOGIN_TOKEN))
+      .setLabel('Login to MEF')
+      .setStyle(ButtonStyle.Secondary);
+  }
+}

--- a/src/channels/consider/screens/ConsiderationHomeScreen.ts
+++ b/src/channels/consider/screens/ConsiderationHomeScreen.ts
@@ -23,6 +23,7 @@ import { CONSIDERATION_CONSTANTS } from '../Constants';
 import { EndUserError } from '../../../Errors';
 import { ConsiderationFundingRoundPaginator } from '../../../components/FundingRoundPaginator';
 import { DiscordLimiter } from '../../../utils/DiscordLimiter';
+import { GenerateLoginTokenAction } from '../actions/GenerateLoginTokenAction';
 
 export class ConsiderationHomeScreen extends Screen implements IHomeScreen {
   public static readonly ID = CONSIDERATION_CONSTANTS.SCREEN_IDS.HOME;
@@ -33,6 +34,7 @@ export class ConsiderationHomeScreen extends Screen implements IHomeScreen {
   public readonly selectVoteTypeAction: SelectVoteTypeAction;
   public readonly selectProjectAction: SelectProjectAction;
   public readonly smeConsiderationVoteAction: SMEConsiderationVoteAction;
+  public readonly generateLoginTokenAction: GenerateLoginTokenAction;
 
   constructor(dashboard: Dashboard, screenId: string) {
     super(dashboard, screenId);
@@ -40,6 +42,7 @@ export class ConsiderationHomeScreen extends Screen implements IHomeScreen {
     this.selectVoteTypeAction = new SelectVoteTypeAction(this, CONSIDERATION_CONSTANTS.ACTION_IDS.SELECT_VOTE_TYPE);
     this.selectProjectAction = new SelectProjectAction(this, CONSIDERATION_CONSTANTS.ACTION_IDS.SELECT_PROJECT);
     this.smeConsiderationVoteAction = new SMEConsiderationVoteAction(this, CONSIDERATION_CONSTANTS.ACTION_IDS.SME_CONSIDERATION_VOTE);
+    this.generateLoginTokenAction = new GenerateLoginTokenAction(this, CONSIDERATION_CONSTANTS.ACTION_IDS.GENERATE_LOGIN_TOKEN);
   }
 
   public async renderToTextChannel(channel: TextChannel): Promise<void> {
@@ -52,7 +55,13 @@ export class ConsiderationHomeScreen extends Screen implements IHomeScreen {
   }
 
   protected allActions(): Action[] {
-    return [this.selectFundingRoundAction, this.selectVoteTypeAction, this.selectProjectAction, this.smeConsiderationVoteAction];
+    return [
+      this.selectFundingRoundAction,
+      this.selectVoteTypeAction,
+      this.selectProjectAction,
+      this.smeConsiderationVoteAction,
+      this.generateLoginTokenAction,
+    ];
   }
 
   protected async getResponse(interaction?: TrackedInteraction, args?: RenderArgs): Promise<any> {
@@ -68,7 +77,9 @@ export class ConsiderationHomeScreen extends Screen implements IHomeScreen {
       .setLabel('Select Funding Round')
       .setStyle(ButtonStyle.Primary);
 
-    const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(selectFundingRoundButton);
+    const loginButton = this.generateLoginTokenAction.getComponent();
+
+    const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(selectFundingRoundButton, loginButton);
 
     return {
       embeds: [embed],

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,71 @@
+import * as jose from 'jose';
+import { ButtonInteraction } from 'discord.js';
+
+/**
+ * Interface for generating and verifying JWT tokens for authentication with MEF Web App.
+ */
+export class AuthTokenGenerator {
+  private privateKey: jose.KeyLike | null = null;
+  private publicKey: jose.KeyLike | null = null;
+
+  constructor(
+    private readonly clientId: string,
+    private readonly baseUrl: string,
+    private readonly privateKeyStr: string,
+    private readonly publicKeyStr: string,
+  ) {}
+
+  async initialize() {
+    if (!this.privateKey || !this.publicKey) {
+      this.privateKey = await jose.importPKCS8(this.privateKeyStr, 'RS512');
+      this.publicKey = await jose.importSPKI(this.publicKeyStr, 'RS512');
+    }
+  }
+
+  async generateLoginUrl(interaction: ButtonInteraction): Promise<string> {
+    await this.initialize();
+
+    if (!this.privateKey) {
+      throw new Error('Token generator not initialized');
+    }
+
+    const iat = Math.floor(Date.now() / 1000);
+    const exp = iat + 30; // 30 seconds expiration
+
+    const authSource = {
+      type: 'discord' as const,
+      id: interaction.user.id,
+      username: interaction.user.username,
+    };
+
+    const jwt = await new jose.SignJWT({
+      authSource,
+      iss: 'initial',
+      sub: authSource.id,
+      jti: crypto.randomUUID(),
+    })
+      .setProtectedHeader({ alg: 'RS512' })
+      .setIssuedAt(iat)
+      .setExpirationTime(exp)
+      .sign(this.privateKey);
+
+    return `${this.baseUrl}/auth?token=${jwt}`;
+  }
+
+  async verifyToken(token: string) {
+    await this.initialize();
+
+    if (!this.publicKey) {
+      throw new Error('Token generator not initialized');
+    }
+
+    try {
+      const { payload } = await jose.jwtVerify(token, this.publicKey, {
+        algorithms: ['RS512'],
+      });
+      return payload;
+    } catch (error) {
+      throw new Error('Invalid token');
+    }
+  }
+}


### PR DESCRIPTION
# Login To MEF WeApp From Discord

This PR implements the stateless JWT login from Discord to MEF Web App, by adding a "Login To MEF" button in the `#consider` channel.

**BEFORE DEPLOYING, THE FOLLOWING ENV VARS MUST BE SET**:

`MEF_FE_BASE_URL` - the url for the MEF Web App frontend (https://github.com/MinaFoundation/pgt-gov-bot-web-app), **without an ending slash**. e.g.: "MEF_FE_BASE_URL=https://my-domain.com"

`JWT_PRIVATE_KEY_RS512` - same value as in https://github.com/MinaFoundation/pgt-gov-bot-web-app
`JWT_PUBLIC_KEY_RS512` - same value as in https://github.com/MinaFoundation/pgt-gov-bot-web-app

Only after those env vars are set this new version can be deployed.

Thank you.